### PR TITLE
move help box to just under help button

### DIFF
--- a/src/main/webapp/WEB-INF/templates/views/edit.ssp
+++ b/src/main/webapp/WEB-INF/templates/views/edit.ssp
@@ -32,14 +32,15 @@
                     <div class="form-group">
                         <label>Example
                         <button class="btn-xs btn btn-info" onclick="$('#examples-help').toggle();return false">Help</button></label>
+
+                        <div id="examples-help" class="cwn-help">
+                            <p>These are some examples from Twitter to help you check you understand the term</p>
+                        </div>
 <blockquote>
                         #for (example <- entry.examples)
                             <p>${example.text}</p>
                         #end
 </blockquote>
-                        <div id="examples-help" class="cwn-help">
-                            <p>These are some examples from Twitter to help you check you understand the term</p>
-                        </div>
                     </div>
                     <div class="form-group">
                         <label for="confidence">Confidence


### PR DESCRIPTION
The help box for the examples list appears below the examples - it's a bit confusing as it's fairly distant from the button you click to make it appear. This moves it's div above the examples themselves.